### PR TITLE
Fix al calcular codigo de estado Mexico Sepomex

### DIFF
--- a/lib/burox/utils/state_code.ex
+++ b/lib/burox/utils/state_code.ex
@@ -5,6 +5,8 @@ defmodule Burox.Utils.StateCode do
   """
 
   @states_codes [
+    Mexico: "EM",
+    CDMX: "CDMX",
     Aguascalientes: "AGS",
     "Baja California": "BCN",
     "Baja California Sur": "BCN",

--- a/lib/burox/utils/state_code.ex
+++ b/lib/burox/utils/state_code.ex
@@ -5,14 +5,13 @@ defmodule Burox.Utils.StateCode do
   """
 
   @states_codes [
-    Mexico: "EM",
-    CDMX: "CDMX",
     Aguascalientes: "AGS",
     "Baja California": "BCN",
-    "Baja California Sur": "BCN",
+    "Baja California Sur": "BCS",
     Campeche: "CAM",
     Chiapas: "CHS",
     Chihuahua: "CHI",
+    CDMX: "CDMX",
     "Ciudad de México": "CDMX",
     Coahuila: "COA",
     Colima: "COL",
@@ -22,6 +21,7 @@ defmodule Burox.Utils.StateCode do
     Guerrero: "GRO",
     Hidalgo: "HGO",
     Jalisco: "JAL",
+    Mexico: "EM",
     "Michoacán": "MICH",
     Morelos: "MOR",
     Nayarit: "NAY",


### PR DESCRIPTION
Sepomex devuelve el Estado de México como "México" y esto generaba un error al calcular su código ya que se parecía más a "Michoacán" que a "Estado de México" al usar `jaro_distance`.
Esto generaba errores al consultar algunos datos de buró.