### PR TITLE
Regresar errores mas claros de buro

### DIFF
--- a/lib/response/config.ex
+++ b/lib/response/config.ex
@@ -904,7 +904,7 @@ defmodule Burox.Response.Config do
           "type" => "string"
            },
         "05" => %{
-          "key" => :ultima_informacion_valida_del_cliente,
+          "key" => :informacion_a_validar_del_cliente,
           "type" => "string"
            },
         "06" => %{

--- a/lib/response/parser.ex
+++ b/lib/response/parser.ex
@@ -30,6 +30,14 @@ defmodule Burox.Response.Parser do
     "ES"
   ]
 
+  @error_translations [
+    {"PN",    "Nombre del cliente"},
+    {"PA",    "Dirección del cliente"},
+    {"PE",    "Empleo del cliente (Domicilio)"},
+    {"PI",    "Referencia de cuentas o créditos"},
+    {"ES",     "Cierre"}
+  ]
+
   @doc """
   Procesa y parsea la cadena recibida del Buró de Crédito
   """
@@ -53,7 +61,7 @@ defmodule Burox.Response.Parser do
         |> _process_response(@error_sections)
         |> Map.get(:error)
         |> Map.to_list()
-
+        |> translate_errors()
       {:error, errors}
     end
 
@@ -264,6 +272,28 @@ defmodule Burox.Response.Parser do
        Keyword.merge(sections, [score: new_values])
       end
   end
+
+  # Traduce una lista de errores
+  
+  defp translate_errors([{key, val} = head | tail]) do
+    [{key, translate_error(val)} | translate_errors(tail)]
+  end
+  defp translate_errors(any), do: any
+
+  defp translate_error(error) do
+    error
+    |> String.slice(0..1)
+    |> validate_error()
+    |> get_error_value(error)
+  end
+
+  defp validate_error(key) do
+    @error_translations
+    |> List.keyfind(key, 0)
+  end
+
+  defp get_error_value({_, value}, _), do: value
+  defp get_error_value(_, value), do: value
 
 end
 

--- a/lib/response/response.ex
+++ b/lib/response/response.ex
@@ -248,7 +248,7 @@ defmodule Burox.Response.ErrorUser do
     :producto_solicitado_erroneo,
     :clave_de_usuario_o_contrasena_erronea,
     :segmento_requerido_no_proporcionado,
-    :ultima_informacion_valida_del_cliente,
+    :informacion_a_validar_del_cliente,
     :informacion_erronea_para_consulta,
     :valor_erroneo_en_una_campo_relacionado,
     :error_en_el_sistema_de_buro_de_credito,

--- a/test/burox_test.exs
+++ b/test/burox_test.exs
@@ -137,7 +137,7 @@ defmodule BuroxTest do
                        producto_solicitado_erroneo: nil,
                        segmento_requerido_no_proporcionado: nil,
                        solicitud_del_cliente_erronea: nil,
-                       ultima_informacion_valida_del_cliente: nil,
+                       informacion_a_validar_del_cliente: nil,
                        valor_erroneo_en_una_campo_relacionado: nil,
                        version_proporcionada_erronea: nil
                      },
@@ -219,12 +219,12 @@ defmodule BuroxTest do
     end)
 
     assert Burox.solicitar(@valid_person_data) ==
-             {:ok,
+             {:error,
               %{
                 cadena_respuesta: "ERRRUR25                         1101YES05000530002**",
-                respuesta: {:error, [
+                respuesta: [
                                error_en_el_sistema_de_buro_de_credito: "Y",
-                               numero_de_referencia_del_operador: "                         "]},
+                               numero_de_referencia_del_operador: "                         "],
                 cadena_peticion: @valid_person_data_string
               }}
   end
@@ -236,14 +236,13 @@ defmodule BuroxTest do
     end)
 
     assert Burox.solicitar(@valid_person_data) ==
-             {:ok,
+             {:error,
               %{
                 cadena_peticion: @valid_person_data_string,
                 cadena_respuesta: @invalid_user_response,
-                respuesta: {:error, [
+                respuesta: [
                                clave_de_usuario_o_contrasena_erronea: "UserPassword",
                                numero_de_referencia_del_operador: "                         "]
-                }
               }
              }
   end
@@ -255,12 +254,11 @@ defmodule BuroxTest do
     end)
 
     assert Burox.solicitar(@valid_person_data) ==
-    {:ok, %{
+    {:error, %{
         cadena_peticion:  @valid_person_data_string,
         cadena_respuesta: "ERRRAR25                         0014NO AUTENTICADOES05000660002**",
-        respuesta: {:error, [
-                       numero_de_referencia_del_operador: "                         ",
-                       solicitud_del_cliente_erronea: "NO AUTENTICADO"]}
+        respuesta: [numero_de_referencia_del_operador: "                         ",
+                       solicitud_del_cliente_erronea: "NO AUTENTICADO"]
      }
     }
   end


### PR DESCRIPTION
Regresar las cadenas de error traducidas a errores mas claros para el usuario.
- Se cambia la llave `ultima_informacion_valida_del_cliente` por `informacion_a_validar_del_cliente` para evitar confusiones.
- Se agregan traducciones de los posibles errores arrojados por buro


Ejemplos de cadenas de error traducidas:

Cadena: `ERRRUR25                         0506PA13020614PAPA08SAMARIA ES05000760002**`
Parseada:
```
{:error,
 [
   informacion_a_validar_del_cliente: "Dirección del cliente",
   informacion_erronea_para_consulta: "Dirección del cliente",
   numero_de_referencia_del_operador: "                         "
 ]}
```

Cadena: `ERRRUR25                         0506PN0204ES05000580002**`
Parseada:
```
{:error,
 [
   informacion_a_validar_del_cliente: "Nombre del cliente",
   numero_de_referencia_del_operador: "                         "
 ]}
```