### PR TITLE
Parsear buro correctamente

### DIFF
--- a/lib/response/parser.ex
+++ b/lib/response/parser.ex
@@ -187,8 +187,13 @@ defmodule Burox.Response.Parser do
     is_same_section = section == next_tag
     cond do
       is_same_section ->
+        clean_values =
+          values
+          |> Map.keys()
+          |> Map.new(fn val -> {val, nil} end)
+
         {next_values, final_tail} =
-          _match_section(section, tail, "", values, sections)
+          _match_section(section, tail, "", clean_values, sections)
 
         {List.flatten([values] ++ [next_values]) , final_tail}
 


### PR DESCRIPTION
Solucionar bug que generaba cuentas con fecha de cierre que no deberían tenerla.

Al llamar de forma recursiva la función `_match_section/5` cuando una sección se repetia, se enviaban como valores de la nueva seccion los valores ya obtenidos de la sección anterior. Si la nueva sección no tenía nuevos datos, los valores de la sección anterior no se sobreescribian, generando así inconsistencias en la información, en deudas, direcciones y cualquier sección que pudiera repetirse y que no tuviera todos los valores.


- [x] Mandar la lista de llaves de la sección como un mapa con todos los valores nulos para que, en caso de no sobreescribirse todos los valores, se queden con un valor nulo y no con el valor correspondiente a la sección anterior.

Diferencias después del cambio al traducir las secciones de domicilio del usuario en la siguiente cadena:
`PA21ANTONIO ALVAREZ 18 SN0116IGNACIO ZARAGOZA0207MORELIA0307MORELIA0404MICH050558114060823091908071044339031801001H1208150420131302MXPA22AND EMILIANO ZAPATA 270017ANIBAL PONCE AMPL0215LAZARO CARDENAS0404MICH050560990120821072004PE16GOBIERNO FEDERAL0018PERIF PA DE 1422 00223EL MIRADOR DEL PUNHUATO0307MORELIA0407MORELIA0504MICH060558249071044332315891708080820162002MXPE31SEDESOL OPORTUNIDADES MICHOACAN00001003COO1108191020121708191020152002MX`

Antes del cambio:
```
[
%{
    ciudad: "MORELIA",
    codigo_postal: "58114",
    colonia: "IGNACIO ZARAGOZA",
    estado: "MICH",
    fecha_de_reporte_de_la_direccion: ~D[2013-04-15],
    fecha_de_residencia: ~D[1908-09-23],
    municipio: "MORELIA",
    numero_de_telefono: "4433903180",
    origen_del_domicilio: "MX",
    primera_linea_de_direccion: "ANTONIO ALVAREZ 18 SN",
    tipo_de_domicilio: "H"
  },
  %{
    ciudad: "MORELIA",
    codigo_postal: "60990",
    colonia: "IGNACIO ZARAGOZA",
    estado: "MICH",
    fecha_de_reporte_de_la_direccion: ~D[2004-07-21],
    fecha_de_residencia: ~D[1908-09-23],
    municipio: "LAZARO CARDENAS",
    numero_de_telefono: "4433903180",
    origen_del_domicilio: "MX",
    primera_linea_de_direccion: "AND EMILIANO ZAPATA 27",
    segunda_linea_de_direccion: "ANIBAL PONCE AMPL",
    tipo_de_domicilio: "H"
  }
]
```

Después del cambio:
```
[
  %{
    ciudad: "MORELIA",
    codigo_postal: "58114",
    colonia: "IGNACIO ZARAGOZA",
    estado: "MICH",
    fecha_de_reporte_de_la_direccion: ~D[2013-04-15],
    fecha_de_residencia: ~D[1908-09-23],
    municipio: "MORELIA",
    numero_de_telefono: "4433903180",
    origen_del_domicilio: "MX",
    primera_linea_de_direccion: "ANTONIO ALVAREZ 18 SN",
    tipo_de_domicilio: "H"
  },
  %{
    ciudad: nil,
    codigo_postal: "60990",
    colonia: nil,
    estado: "MICH",
    fecha_de_reporte_de_la_direccion: ~D[2004-07-21],
    fecha_de_residencia: nil,
    municipio: "LAZARO CARDENAS",
    numero_de_telefono: nil,
    origen_del_domicilio: nil,
    primera_linea_de_direccion: "AND EMILIANO ZAPATA 27",
    segunda_linea_de_direccion: "ANIBAL PONCE AMPL",
    tipo_de_domicilio: nil
  }
```