### PR TITLE
[Fix] Credential validation recursion

### DIFF
--- a/lib/request/encoder.ex
+++ b/lib/request/encoder.ex
@@ -83,14 +83,14 @@ defmodule Burox.Request.Encoder do
   @spec validate_credentials(
     {String.t(), String.t(), String.t()}
   ) :: {String.t(), String.t(), String.t()}
+  defp validate_credentials({nil, nil, _version}), do: raise Burox.Error,
+    message: "Deben configurarse las credenciales del buró de crédito"
+
   defp validate_credentials({nil, _password, _version}),
     do: validate_credentials({nil, nil, nil})
 
   defp validate_credentials({_user, nil, _version}),
     do: validate_credentials({nil, nil, nil})
-
-  defp validate_credentials({nil, nil, _version}), do: raise Burox.Error,
-    message: "Deben configurarse las credenciales del buró de crédito"
 
   defp validate_credentials(credentials), do: credentials
 

--- a/lib/request/encoder.ex
+++ b/lib/request/encoder.ex
@@ -83,14 +83,8 @@ defmodule Burox.Request.Encoder do
   @spec validate_credentials(
     {String.t(), String.t(), String.t()}
   ) :: {String.t(), String.t(), String.t()}
-  defp validate_credentials({nil, nil, _version}), do: raise Burox.Error,
-    message: "Deben configurarse las credenciales del buró de crédito"
-
-  defp validate_credentials({nil, _password, _version}),
-    do: validate_credentials({nil, nil, nil})
-
-  defp validate_credentials({_user, nil, _version}),
-    do: validate_credentials({nil, nil, nil})
+  defp validate_credentials({user, password, _version}) when is_nil(user) or is_nil(password),
+    do: raise(Burox.Error, message: "Deben configurarse las credenciales del buró de crédito")
 
   defp validate_credentials(credentials), do: credentials
 


### PR DESCRIPTION
## What's the problem?

If a buro credential is missing, the application enter in an infinite cycle because the pattern match has a bug.

## What did I do to solve the problem?

Change the pattern match position to raise the exception